### PR TITLE
Added trim function to remove new line chars from kube secrets

### DIFF
--- a/lib/upbot.js
+++ b/lib/upbot.js
@@ -17,8 +17,8 @@ try {
   var config = yaml.safeLoad(fs.readFileSync('config.yaml', 'utf8'));
   var intent = config.intent;
   var slack_token = process.env.HODQ_SLACK_API_TOKEN;
-  var redis_host = process.env.UPBOT_REDIS_HOST;
-  var redis_port = process.env.UPBOT_REDIS_PORT;
+  var redis_host = process.env.UPBOT_REDIS_HOST.trim();
+  var redis_port = process.env.UPBOT_REDIS_PORT.trim();
 
   var listenFor = 'direct_message,direct_mention,mention'
 


### PR DESCRIPTION
Protects the app from failures caused by the kube secrets containing a new line character (`\n`) at the end of the value within the encoded value.